### PR TITLE
Typescript Improvements

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,20 +1,25 @@
 declare module 'css-vars-hook' {
   import * as React from 'react';
 
-  type ThemeObject = Record<string, string>;
+  /**
+   * This interface can be augmented by users to add default types for the theme
+   * Use module augmentation to append your own type definition in a your_custom_type.d.ts file.
+   * https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+   */
+  interface ThemeObject extends Record<string, string> { }
 
   type Value = string | number;
 
-  interface HookInterface {
+  interface HookInterface<ThemeType = ThemeObject> {
     ref: React.RefObject<HTMLElement>;
     setRef: (element: HTMLElement | null) => void;
-    style: ThemeObject;
-    setVariable: (variableName: string, value: Value) => void;
-    getVariable: (variableName: string) => string;
-    removeVariable: (variableName: string) => void;
+    style: ThemeType;
+    setVariable: (variableName: keyof ThemeType, value: Value) => void;
+    getVariable: (variableName: keyof ThemeType) => string;
+    removeVariable: (variableName: keyof ThemeType) => void;
   }
 
-  export function useTheme(theme: ThemeObject): HookInterface;
+  export function useTheme<ThemeType = ThemeObject>(theme: ThemeType): HookInterface<ThemeType>;
 
-  export function useVariable(name: string, value: Value): HookInterface;
+  export function useVariable(name: string, value: Value): HookInterface<Record<string, Value>>;
 }


### PR DESCRIPTION
This PR includes some Typescript changes.

Firstly, the default `ThemeObject` can be augmented like this in user's project:

```
declare module 'css-vars-hook' {
  interface ThemeObject {
    backgroundColor?: string;
  }
}
```

Also, theme type can also be selected like `useTheme<MyCustomThemeType>`.
